### PR TITLE
remove HAL traits (unneeded with updates to ht16k33)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ documentation = "https://docs.rs/adafruit-7segment"
 homepage = "https://github.com/kallemooo/adafruit-7segment"
 
 [dependencies]
-ht16k33 = { version = "0.4.0", default-features = false }
-embedded-hal  = { version = "0.2.3" }
+ht16k33 = { version = "0.4.0", default-features = false, git="https://github.com/danjl1100/ht16k33", branch = "data-only-methods" }
 ascii = { version = "1.0.0", default-features = false }
+
+[dev-dependencies]
+embedded-hal  = { version = "1.0.0-rc.1" }
 
 [dev-dependencies.embedded-hal-mock]
 version = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,6 @@ mod fonts;
 use fonts::*;
 
 pub use ascii::{AsciiChar, ToAsciiChar};
-use embedded_hal::blocking::i2c::{Write, WriteRead};
 use ht16k33::{DisplayData, DisplayDataAddress, LedLocation, COMMONS_SIZE, HT16K33};
 
 /// Possible errors returned by this crate.
@@ -163,7 +162,7 @@ pub enum Error {
 }
 
 /// Trait enabling using the Adafruit 7-segment LED numeric Backpack.
-pub trait SevenSegment<E> {
+pub trait SevenSegment {
     /// Update the buffer with a digit value (0 to F) at the specified index.
     fn update_buffer_with_digit(&mut self, index: Index, value: u8);
     /// Update the buffer to turn the . on or off at the specified index.
@@ -224,10 +223,7 @@ const DOT_BIT: u8 = 7;
 
 const COLON_BIT: u8 = 1;
 
-fn set_bit<I2C, E>(display: &mut HT16K33<I2C>, index: u8, bit: u8, on: bool)
-where
-    I2C: Write<Error = E> + WriteRead<Error = E>,
-{
+fn set_bit<I2C>(display: &mut HT16K33<I2C>, index: u8, bit: u8, on: bool) {
     debug_assert!((bit as usize) < (COMMONS_SIZE * 2));
     let index = index * 2;
     let row = DisplayDataAddress::from_bits_truncate(if bit < 8 { index } else { index + 1 });
@@ -235,10 +231,7 @@ where
     display.update_display_buffer(LedLocation { row, common }, on);
 }
 
-fn update_bits<I2C, E>(display: &mut HT16K33<I2C>, index: Index, bits: u8)
-where
-    I2C: Write<Error = E> + WriteRead<Error = E>,
-{
+fn update_bits<I2C>(display: &mut HT16K33<I2C>, index: Index, bits: u8) {
     let pos: u8;
     if index > Index::Two {
         // Move one step to compensate for colon at pos 2.
@@ -252,10 +245,7 @@ where
     }
 }
 
-impl<I2C, E> SevenSegment<E> for HT16K33<I2C>
-where
-    I2C: Write<Error = E> + WriteRead<Error = E>,
-{
+impl<I2C> SevenSegment for HT16K33<I2C> {
     /// Update the buffer with a hex digit value (0x00 to 0x0F) at the specified index
     /// # Arguments
     ///


### PR DESCRIPTION
### Motivation

The fewer driver crates with opinions on which HAL library version to use, the better.

### Solution
The trait supplied by this library does not perform IO.  When (or if) `ht16k33` relaxes the bounds, then this crate doesn't even need a dependency on a specific HAL.

This change is dependent on `ht16k33` merging https://github.com/jasonpeacock/ht16k33/pull/22. Since this library is only manipulating the display buffer, the user will only need to agree with the HAL trait used in  `ht16k33` IO methods. (e.g. one fewer crate to patch)

### Notes
- `Cargo.toml` will need to be edited when/if `ht16k33` removes HAL trait bounds from the non-IO methods (PR linked above) but it currently shows the version that is proposed (branch "data-only-methods" on my fork)
